### PR TITLE
Property Reference Update

### DIFF
--- a/main.tmpl.go
+++ b/main.tmpl.go
@@ -31,7 +31,7 @@ func main() {
 		Frameless:         false,
 		StartHidden:       false,
 		HideWindowOnClose: false,
-		RGBA:              &options.RGBA{255, 255, 255, 255},
+		BackgroundColour:  &options.RGBA{R: 255, G: 255, B: 255, A: 255},
 		Assets:            assets,
 		LogLevel:          logger.DEBUG,
 		OnStartup:         app.startup,


### PR DESCRIPTION
RGBA is no longer a recognized reference and as such wails will no longer build. Updated the template to reflect the change to Options and keyed the default values as to not produce warnings.